### PR TITLE
Minor improvement to the work approach checklist

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -43,7 +43,7 @@ Gruber
 - ./protocols/development-process/README.md
 Evo
 
-- ./protocols/development-process/work-approach-checklist.md
+- ./protocols/development-process/work-approach-checklist/README.md
 deliverables
 UI-flow
 Wireframe

--- a/bin/add-toc.sh
+++ b/bin/add-toc.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# ==============================================================================
+#/ This script recursively scans all markdown files in a given directory and
+#/ replaces all occurrences of "<!-- toc -->" with an actual table of content.
+#/
+#/ Requires the markdown-toc node module to be available in the project.
+# ------------------------------------------------------------------------------
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+shortUsage() {
+        echo ''
+        echo 'Usage: '
+        echo "         $0 <directory-to-scan>"
+        echo ''
+}
+
+fullUsage() {
+    grep '^#/' <"$0" | cut -c4-
+}
+
+add-toc() {
+    local aFiles sDirectory sFile
+     sDirectory="${1}"
+
+    aFiles=$(grep --recursive --files-with-matches --include='*.md' --exclude-dir={node_modules,_site} '<!-- toc -->' "${sDirectory}")
+
+
+    for sFile in "${aFiles[@]}";do
+        ./node_modules/.bin/markdown-toc -i "${sFile}"
+    done
+}
+
+main() {
+    local bShowHelp
+
+    bShowHelp=false
+
+    if [ ! "$#" -eq 1 ];then
+        echo 'This script expects one argument: the path to the folder to scan.' 1>&2
+        shortUsage
+        exit 65
+    fi
+
+    for sParam in "$@";do
+        if [ "${sParam}" = "--help" ];then
+            bShowHelp=true
+        fi
+    done
+
+    if [ "${bShowHelp}" == "true" ];then
+        fullUsage
+        shortUsage
+    else
+        add-toc "$@"
+    fi
+}
+# ==============================================================================
+
+
+# ==============================================================================
+if [ "${0}" = "${BASH_SOURCE[0]}" ];then
+    # direct call to file
+    main "$@"
+fi # else file is included from another script
+# ==============================================================================
+
+#EOF

--- a/bin/add-toc.sh
+++ b/bin/add-toc.sh
@@ -1,39 +1,116 @@
 #!/usr/bin/env bash
-
 # ==============================================================================
 #/ This script recursively scans all markdown files in a given directory and
 #/ replaces all occurrences of "<!-- toc -->" with an actual table of content.
 #/
 #/ Requires the markdown-toc node module to be available in the project.
+# ==============================================================================
+# MIT License
+#
+# Copyright (c) 2017 Dealerdirect B.V.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+# ==============================================================================
+set -o errexit  # Exit script when a command exits with non-zero status
+set -o nounset  # Exit script on use of an undefined variable
+set -o pipefail # Return exit status of the last command in the pipe that failed
+
+# ==============================================================================
+# GLOBALS
+# ==============================================================================
+readonly EX_OK=0                        # Successful termination
+readonly EX_NOT_ENOUGH_PARAMETERS=65    # Successful termination
+
+# ==============================================================================
+# UTILITY
+# ==============================================================================
 # ------------------------------------------------------------------------------
-
-set -o errexit
-set -o nounset
-set -o pipefail
-
-shortUsage() {
-        echo ''
-        echo 'Usage: '
-        echo "         $0 <directory-to-scan>"
-        echo ''
+# Displays how this script should be used
+#
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   None
+# ------------------------------------------------------------------------------
+short_usage() {
+    echo ''
+    echo 'Usage: '
+    echo "         $0 <directory-to-scan>"
+    echo ''
 }
 
-fullUsage() {
+# ------------------------------------------------------------------------------
+# Displays all lines in main script that start with '#/'
+#
+# Globals:
+#   None
+# Arguments:
+#   None
+# Returns:
+#   None
+# ------------------------------------------------------------------------------
+full_usage() {
     grep '^#/' <"$0" | cut -c4-
 }
 
-add-toc() {
+# ==============================================================================
+# SCRIPT LOGIC
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Scans a given directory for `.md` files and replaces any `<!-- toc -->` it
+# finds with an actual table of content, using the markdown-toc node module
+#
+# Globals:
+#   None
+# Arguments:
+#   $1 The directory to scan
+# Returns:
+#   None
+# ------------------------------------------------------------------------------
+add_toc() {
     local aFiles sDirectory sFile
-     sDirectory="${1}"
+
+    sDirectory="${1}"
 
     aFiles=$(grep --recursive --files-with-matches --include='*.md' --exclude-dir={node_modules,_site} '<!-- toc -->' "${sDirectory}")
-
 
     for sFile in "${aFiles[@]}";do
         ./node_modules/.bin/markdown-toc -i "${sFile}"
     done
 }
 
+# ==============================================================================
+# RUN LOGIC
+# ------------------------------------------------------------------------------
+# Triggers the main functionality or displays usage, depending on arguments.
+#
+# Globals:
+#   EX_OK
+#   EX_NOT_ENOUGH_PARAMETERS
+# Arguments:
+#   $1 The directory to scan OR `--help` to display the usage
+# Returns:
+#   None
+# ------------------------------------------------------------------------------
 main() {
     local bShowHelp
 
@@ -41,8 +118,8 @@ main() {
 
     if [ ! "$#" -eq 1 ];then
         echo 'This script expects one argument: the path to the folder to scan.' 1>&2
-        shortUsage
-        exit 65
+        short_usage
+        exit ${EX_NOT_ENOUGH_PARAMETERS}
     fi
 
     for sParam in "$@";do
@@ -52,11 +129,13 @@ main() {
     done
 
     if [ "${bShowHelp}" == "true" ];then
-        fullUsage
-        shortUsage
+        full_usage
+        short_usage
     else
-        add-toc "$@"
+        add_toc "$@"
     fi
+
+    exit ${EX_OK}
 }
 # ==============================================================================
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "alex": "^4.0.1",
     "markdown-spellcheck": "^0.11.0",
+    "markdown-toc": "^1.1.0",
     "remark-cli": "^2.1.0",
     "remark-lint": "^5.2.0",
     "remark-lint-books-links": "^1.0.0",

--- a/protocols/README.md
+++ b/protocols/README.md
@@ -18,3 +18,7 @@ Protocols are available for the following scenario's:
 - [Deliverables](./development-process/deliverables/) -- Outlines who is 
  responsible for providing which deliverable during the software development 
  process.
+ 
+- [Work Approach Checklist](./development-process/work-approach-checklist/) -- Outlines who is 
+ responsible for providing which deliverable during the software development 
+ process.

--- a/protocols/development-process/README.md
+++ b/protocols/development-process/README.md
@@ -11,3 +11,7 @@ The following protocols are available for the software development process:
 - [Deliverables](./deliverables/) -- Outlines who is 
  responsible for providing which deliverable during the software development 
  process.
+
+- [Work Approach Checklist](./work-approach-checklist/) -- Outlines who is 
+ responsible for providing which deliverable during the software development 
+ process.

--- a/protocols/development-process/work-approach-checklist/README.md
+++ b/protocols/development-process/work-approach-checklist/README.md
@@ -6,8 +6,40 @@ permalink: /protocols/development-process/work-approach-checklist/
 
 # Work approach checklist
 
-- auto-gen TOC:
-{:toc}
+## Table of contents
+
+<!-- toc -->
+
+- [Introduction](#introduction)
+
+- [Start](#start)
+
+- ![](../images/idea.png) **Idea Ticket**
+
+  - [1. **Is the IDEA clear enough to create an IDEA ticket❔**](#1-is-the-idea-clear-enough-to-create-an-idea-ticket)
+  - [2. **What is the impact of the idea on the business❔**](#2-what-is-the-impact-of-the-idea-on-the-business)
+  - [3. **What is the impact of the idea on the current system❔**](#3-what-is-the-impact-of-the-idea-on-the-current-system)
+  - [4. **Which dependencies does the idea have❔**](#4-which-dependencies-does-the-idea-have)
+
+- ![](../images/proposal.png) **Proposal Ticket**
+
+  - [5. **Can a PROPOSAL be created from the available information❔**](#5-can-a-proposal-be-created-from-the-available-information)
+  - [6. **Are all of the specifications clear❔**](#6-are-all-of-the-specifications-clear)
+
+- ![](../images/epic.png) **Epic Ticket**
+
+  - [7. **Can a PROJECT be created from the available information❔**](#7-can-a-project-be-created-from-the-available-information)
+  - [8. **Have all low-level dependencies been met❔**](#8-have-all-low-level-dependencies-been-met)
+
+- ![](../images/story.png) **Story Ticket**
+
+  - [9. **Can a high-level description be created❔**](#9-can-a-high-level-description-be-created)
+
+- ![](../images/task.png) **Task Ticket** ![](../images/subtask.png) **Sub-Task Ticket**
+
+  - [10. **Can a low-level work ticket be created❔**](#10-can-a-low-level-work-ticket-be-created)
+
+<!-- tocstop -->
 
 ## Introduction
 

--- a/protocols/development-process/work-approach-checklist/README.md
+++ b/protocols/development-process/work-approach-checklist/README.md
@@ -1,8 +1,8 @@
 ---
-permalink: /protocols/development-process/work-approach-checklist.html
+permalink: /protocols/development-process/work-approach-checklist/
 ---
 
-<link rel="stylesheet" href="roles.css" />
+<link rel="stylesheet" href="../roles.css" />
 
 # Work approach checklist
 
@@ -44,7 +44,7 @@ Master or QA)
 
 -------------------------------------------------------------------------------
 
-## ![](images/idea.png) Idea Ticket
+## ![](../images/idea.png) Idea Ticket
 
 ### 1. **Is the IDEA clear enough to create an IDEA ticket❔**
 
@@ -100,7 +100,7 @@ to be informed or collaborated with?
 
 _Responsibility of_: <span class="role role-product-owner">Product Owner</span>
 
-## ![](images/proposal.png) Proposal Ticket
+## ![](../images/proposal.png) Proposal Ticket
 
 ### 5. **Can a PROPOSAL be created from the available information❔**
 
@@ -122,28 +122,28 @@ need to be created.
 There are various tools available to make matters more clear. Depending on the
 subject, one or more of the following can be used to paint a clear picture:
 
-- ![](images/adobe-xd.png) Graphic Design _Responsibility of_:
+- ![](../images/adobe-xd.png) Graphic Design _Responsibility of_:
   <span class="role role-graphic-designer">Graphic Designer</span>.
 
-- ![](images/bitbucket.png) Proof of Concept _Responsibility of_:
+- ![](../images/bitbucket.png) Proof of Concept _Responsibility of_:
   <span class="role role-programmer">Programmer</span>.
 
-- ![](images/bitbucket.png) Prototype _Responsibility of_:
+- ![](../images/bitbucket.png) Prototype _Responsibility of_:
   <span class="role role-programmer">Programmer</span>.
 
 - ![](https://goo.gl/t857rT) Research Question _Responsibility of_:
   <span class="role role-programmer">Programmer</span>.
 
-- ![](images/image.png) Application/High-level Sequence Diagram _Responsibility of_:
+- ![](../images/image.png) Application/High-level Sequence Diagram _Responsibility of_:
   <span class="role role-product-owner">Product Owner</span>.
 
-- ![](images/image.png) Service/System/Low-Level Sequence Diagram _Responsibility of_:
+- ![](../images/image.png) Service/System/Low-Level Sequence Diagram _Responsibility of_:
   <span class="role role-programmer">Programmer</span>.
 
-- ![](images/image.png) UI-flow Chart _Responsibility of_:
+- ![](../images/image.png) UI-flow Chart _Responsibility of_:
   <span class="role role-ux">User eXperience</span>.
 
-- ![](images/adobe-xd.png) Wireframe _Responsibility of_:
+- ![](../images/adobe-xd.png) Wireframe _Responsibility of_:
   <span class="role role-ux">User eXperience</span>.
 
 Instead of creating these deliverables themselves, a product owner can
@@ -154,7 +154,7 @@ than just the happy path, deviations from the main flow should also be stated.
 
 _Responsibility of_: <span class="role role-product-owner">Product Owner</span>
 
-## ![](images/epic.png) Epic Ticket
+## ![](../images/epic.png) Epic Ticket
 
 ### 7. **Can a PROJECT be created from the available information❔**
 
@@ -185,7 +185,7 @@ If not, what is missing? Who is responsible for the deliverable?
 
 _Responsibility of_: <span class="role role-product-owner">Product Owner</span>
 
-## ![](images/story.png) Story Ticket
+## ![](../images/story.png) Story Ticket
 
 ### 9. **Can a high-level description be created❔**
 
@@ -194,7 +194,7 @@ issue can be planned.
 
 _Responsibility of_: <span class="role role-product-owner">Product Owner</span>
 
-## ![](images/task.png) Task Ticket <br /> ![](images/subtask.png) Sub-Task Ticket
+## ![](../images/task.png) Task Ticket <br /> ![](../images/subtask.png) Sub-Task Ticket
 
 ### 10. **Can a low-level work ticket be created❔**
 

--- a/protocols/development-process/work-approach-checklist/README.md
+++ b/protocols/development-process/work-approach-checklist/README.md
@@ -44,13 +44,19 @@ Master or QA)
 
 -------------------------------------------------------------------------------
 
+## Start
+
+The whole process begins when someone has an idea about how to improve an 
+application so more value can be added for an end user.
+
+_Responsibility of_: (Someone representing the) <span class="role role-end-user">End User</span>
+
 ## ![](../images/idea.png) Idea Ticket
 
 ### 1. **Is the IDEA clear enough to create an IDEA ticket❔**
 
-When an <span class="role role-end-user">End User</span> or stakeholder has
-the idea that something should be changed or added to the system, it should be
-clear what problem the idea addresses.
+When an End User or stakeholder has the idea that something should be changed or 
+added to the system, it should be clear what problem the idea addresses.
 
 The product owner should be able to summarize the goal in one or two sentences.
 


### PR DESCRIPTION
- Add utility script to generate a table-of-content
- Replaces `{:toc}` with an actual table of content (so the TOC is visible in the repo as well)
- Moves checklist to separate repo
- Resolves issue raised by @Terrub in previous PR.