### PR TITLE
Sticky developer pain calculator

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,6 +27,7 @@
 
     <script src="https://cdn.jsdelivr.net/jquery/2.2.4/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/jquery.zoom/1.7.18/jquery.zoom.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/stickyfill/1.1.4/stickyfill.min.js"></script>
     <script>
         $(document).ready(function(){
             $('img[title="zoom"]')

--- a/assets/css/protocols-estimating-developer-pain-criteria.css
+++ b/assets/css/protocols-estimating-developer-pain-criteria.css
@@ -35,7 +35,10 @@
 input.criteria__score {
     font-size: 10em;
     max-width: 100%;
+    position: -webkit-sticky;
+    position: sticky;
     text-align: center;
+    top: 0;
 }
 
 /*EOF*/

--- a/assets/js/protocols-estimating-developer-pain-criteria.js
+++ b/assets/js/protocols-estimating-developer-pain-criteria.js
@@ -78,6 +78,8 @@
 
         g_$Score = $('<input type="text" class="criteria__score" data-score="{}" readonly />');
 
+        g_$Score.Stickyfill();
+
         $Help = $('<p class="criteria__help">' +
             '<span class="octicon octicon-info criteria__help-icon"></span>' +
             'To calculate the developer pain for a given issue, ' +


### PR DESCRIPTION
This PR adds functionality so the part of the Developer Pain Calculator that displays the score sticks to the top of the browser viewport.

This is achieved by using CSS styles for browsers that support `display: sticky` and a JS polyfill for other browsers.

For (terminally) old browser there is simply no sticky header.